### PR TITLE
Make gTTS work with Google's token system

### DIFF
--- a/gtts/tests/test_tts.py
+++ b/gtts/tests/test_tts.py
@@ -53,7 +53,7 @@ class TestInit(unittest.TestCase):
         lang = 'en'
         text = "Hey asshole"
         tts = gTTS(text, lang)
-        self.assertEqual("513085.127987", tts.calculate_token(text))
+        self.assertEqual("514801.130336", tts.calculate_token(text, seed=403409))
 
     def test_work_token(self):
         lang = 'en'

--- a/gtts/tests/test_tts.py
+++ b/gtts/tests/test_tts.py
@@ -1,4 +1,7 @@
-import unittest, tempfile, os
+import os
+import tempfile
+import unittest
+
 from gtts import gTTS
 
 LANGS = [lang for lang in gTTS.LANGUAGES.keys()]
@@ -45,6 +48,20 @@ class TestInit(unittest.TestCase):
         lang = 'en'
         text = ""
         self.assertRaises(Exception, gTTS, text, lang)
+
+    def test_token(self):
+        lang = 'en'
+        text = "Hey asshole"
+        tts = gTTS(text, lang)
+        self.assertEqual("513085.127987", tts.calculate_token(text))
+
+    def test_work_token(self):
+        lang = 'en'
+        tokenkey = 403404
+        text = "Hey asshole"
+        seed = "+-a^+6"
+        tts = gTTS(text, lang)
+        self.assertEqual(415744659, tts.work_token(tokenkey, seed))
 
 class TestTokenizer(unittest.TestCase):
     """Tokenization when text is longer than what is allowed (MAX_CHARS)"""

--- a/gtts/tts.py
+++ b/gtts/tts.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
-import re, requests
+import re
+import requests
+
+
+def rshift(val, n): return val>>n if val >= 0 else (val+0x100000000)>>n
 
 class gTTS:
     """ gTTS (Google Text to Speech): an interface to Google's Text to Speech API """
 
-    GOOGLE_TTS_URL = 'http://translate.google.com/translate_tts'
+    GOOGLE_TTS_URL = 'https://translate.google.com/translate_tts'
     MAX_CHARS = 100 # Max characters the Google TTS API takes at a time
     LANGUAGES = {
         'af' : 'Afrikaans',
@@ -83,25 +87,32 @@ class gTTS:
         text_parts = [strip(x) for x in text_parts]
         text_parts = [x for x in text_parts if len(x) > 0]
         self.text_parts = text_parts
+        self.token_key = None
 
     def save(self, savefile):
         """ Do the Web request and save to `savefile` """
         with open(savefile, 'wb') as f:
             self.write_to_fp(f)
+            f.close()
 
     def write_to_fp(self, fp):
         """ Do the Web request and save to a file-like object """
         for idx, part in enumerate(self.text_parts):
             payload = { 'ie' : 'UTF-8',
-                        'client' : 't',
-                        'tl' : self.lang,
                         'q' : part,
+                        'tl' : self.lang,
                         'total' : len(self.text_parts),
                         'idx' : idx,
-                        'textlen' : len(part) }
+                        'client' : 't',
+                        'textlen' : len(part),
+                        'tk' : self.calculate_token(part)}
+            headers = {
+                "Referer" : "http://translate.google.com/",
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36"
+            }
             if self.debug: print(payload)
             try:
-                r = requests.get(self.GOOGLE_TTS_URL, params=payload)
+                r = requests.get(self.GOOGLE_TTS_URL, params=payload, headers=headers)
                 if self.debug:
                     print("Headers: {}".format(r.request.headers))
                     print("Reponse: {}, Redirects: {}".format(r.status_code, r.history))
@@ -123,6 +134,59 @@ class gTTS:
         for p in parts:
             min_parts += self._minimize(p, " ", max_size)
         return min_parts
+
+    def calculate_token(self, text):
+        if self.token_key is None:
+            r = requests.get("http://translate.google.com")
+            m = re.search(r"TKK='(\d+)'", r.text)
+            self.token_key = int(m.group(1))
+        tk = "tk"
+        e = 0
+        f = 0
+        d = [None] * len(text)
+        for c in text:
+            g = ord(c)
+            if 128 > g:
+                d[e] = g
+                e += 1
+            elif 2048 > g:
+                d[e] = g >> 6 | 192
+                e += 1
+            else:
+                if 55296 == (g & 64512) and f + 1 < len(text) and 56320 == (ord(text[f + 1]) & 64512):
+                    f += 1
+                    g = 65536 + ((g & 1023) << 10) + (ord(text[f]) & 1023)
+                    d[e] = g >> 18 | 240
+                    e += 1
+                    d[e] = g >> 12 & 63 | 128
+                    e += 1
+                else:
+                    d[e] = g >> 12 | 224
+                    e += 1
+                    d[e] = g >> 6 & 63 | 128
+                    e += 1
+                    d[e] = g & 63 | 128
+                    e += 1
+
+        a = self.token_key
+        for value in d:
+            a += value
+            a = self.work_token(a, "+-a^+6")
+        a = self.work_token(a, "+-3^+b+-f")
+        if 0 > a:
+            a = (a & 2147483647) + 2147483648
+        a %= 1E6
+        a = int(a)
+        return str(a) + "." + str(a ^ self.token_key)
+
+    def work_token(self, a, seed):
+        for i in range(0, len(seed) - 2, 3):
+            char = seed[i + 2]
+            d = ord(char[0]) - 87 if char >= "a" else int(char)
+            d = rshift(a, d) if seed[i + 1] == "+" else a << d
+            a = a + d & 4294967295 if seed[i] == "+" else a ^ d
+        return a
+
 
     def _minimize(self, thestring, delim, max_size):
         """ Recursive function that splits `thestring` in chunks

--- a/gtts/tts.py
+++ b/gtts/tts.py
@@ -135,8 +135,8 @@ class gTTS:
             min_parts += self._minimize(p, " ", max_size)
         return min_parts
 
-    def calculate_token(self, text):
-        if self.token_key is None:
+    def calculate_token(self, text, seed=None):
+        if self.token_key is None and seed is None:
             r = requests.get("http://translate.google.com")
             m = re.search(r"TKK='(\d+)'", r.text)
             self.token_key = int(m.group(1))
@@ -168,7 +168,7 @@ class gTTS:
                     d[e] = g & 63 | 128
                     e += 1
 
-        a = self.token_key
+        a = seed if seed is not None else self.token_key
         for value in d:
             a += value
             a = self.work_token(a, "+-a^+6")

--- a/gtts/tts.py
+++ b/gtts/tts.py
@@ -143,7 +143,7 @@ class gTTS:
 
     def calculate_token(self, text, seed=None):
         if self.token_key is None and seed is None:
-            r = requests.get(GOOGLE_TRANSLATE_URL)
+            r = requests.get(self.GOOGLE_TRANSLATE_URL)
             m = re.search(r"TKK='(\d+)'", r.text)
             self.token_key = int(m.group(1))
         tk = "tk"
@@ -177,8 +177,8 @@ class gTTS:
         a = seed if seed is not None else self.token_key
         for value in d:
             a += value
-            a = self.work_token(a, SALT_1)
-        a = self.work_token(a, SALT_2)
+            a = self.work_token(a, self.SALT_1)
+        a = self.work_token(a, self.SALT_2)
         if 0 > a:
             a = (a & 2147483647) + 2147483648
         a %= 1E6

--- a/gtts/tts.py
+++ b/gtts/tts.py
@@ -3,6 +3,7 @@ import re
 import requests
 
 
+
 def rshift(val, n): return val>>n if val >= 0 else (val+0x100000000)>>n
 
 class gTTS:
@@ -63,6 +64,11 @@ class gTTS:
         'vi' : 'Vietnamese',
         'cy' : 'Welsh'
     }
+
+    GOOGLE_TRANSLATE_URL = "http://translate.google.com"
+    SALT_1 = "+-a^+6"
+    SALT_2 = "+-3^+b+-f"
+
 
     def __init__(self, text, lang = 'en', debug = False):
         self.debug = debug
@@ -137,7 +143,7 @@ class gTTS:
 
     def calculate_token(self, text, seed=None):
         if self.token_key is None and seed is None:
-            r = requests.get("http://translate.google.com")
+            r = requests.get(GOOGLE_TRANSLATE_URL)
             m = re.search(r"TKK='(\d+)'", r.text)
             self.token_key = int(m.group(1))
         tk = "tk"
@@ -171,8 +177,8 @@ class gTTS:
         a = seed if seed is not None else self.token_key
         for value in d:
             a += value
-            a = self.work_token(a, "+-a^+6")
-        a = self.work_token(a, "+-3^+b+-f")
+            a = self.work_token(a, SALT_1)
+        a = self.work_token(a, SALT_2)
         if 0 > a:
             a = (a & 2147483647) + 2147483648
         a %= 1E6

--- a/token-script.js
+++ b/token-script.js
@@ -1,6 +1,3 @@
-/**
- * Created by Boudewijn on 8-1-2016.
- */
 var cM = function(a) {
             return function() {
                 return a
@@ -29,10 +26,11 @@ var dd = ".";
 fM = function(a) {
     var b;
     if (null === eM) {
-        var c = cM(String.fromCharCode(84));
-        b = cM(String.fromCharCode(75));
+        var c = cM(String.fromCharCode(84)); // char 84 is T
+        b = cM(String.fromCharCode(75)); // char 75 is K
         c = [c(), c()];
         c[1] = b();
+        // So basically we're getting window.TKK
         eM = Number(window[c.join(b())]) || 0
     }
     b = eM;
@@ -43,9 +41,9 @@ fM = function(a) {
     for (var c = cb + d.join(k) +
             of, d = [], e = 0, f = 0; f < a.length; f++) {
         var g = a.charCodeAt(f);
+
         128 > g ? d[e++] = g : (2048 > g ? d[e++] = g >> 6 | 192 : (55296 == (g & 64512) && f + 1 < a.length && 56320 == (a.charCodeAt(f + 1) & 64512) ? (g = 65536 + ((g & 1023) << 10) + (a.charCodeAt(++f) & 1023), d[e++] = g >> 18 | 240, d[e++] = g >> 12 & 63 | 128) : d[e++] = g >> 12 | 224, d[e++] = g >> 6 & 63 | 128), d[e++] = g & 63 | 128)
     }
-    console.log(d)
     a = b || 0;
     for (e = 0; e < d.length; e++) a += d[e], a = dM(a, Vb);
     a = dM(a, Ub);
@@ -54,4 +52,4 @@ fM = function(a) {
     return a.toString() + dd + (a ^ b)
 };
 
-console.log(fM("Hey asshole"));
+console.log(fM("Hello person"));

--- a/token-script.js
+++ b/token-script.js
@@ -1,0 +1,57 @@
+/**
+ * Created by Boudewijn on 8-1-2016.
+ */
+var cM = function(a) {
+            return function() {
+                return a
+            }
+        };
+var of = "=";
+var dM = function(a, b) {
+    for (var c = 0; c < b.length - 2; c += 3) {
+        var d = b.charAt(c + 2),
+            d = d >= t ? d.charCodeAt(0) - 87 : Number(d),
+            d = b.charAt(c + 1) == Tb ? a >>> d : a << d;
+        a = b.charAt(c) == Tb ? a + d & 4294967295 : a ^ d
+    }
+    return a
+};
+
+var eM = null;
+var cb = 0;
+var k = "";
+var Vb = "+-a^+6";
+var Ub = "+-3^+b+-f";
+var t = "a";
+var Tb = "+";
+var dd = ".";
+
+fM = function(a) {
+    var b;
+    if (null === eM) {
+        var c = cM(String.fromCharCode(84));
+        b = cM(String.fromCharCode(75));
+        c = [c(), c()];
+        c[1] = b();
+        eM = Number(window[c.join(b())]) || 0
+    }
+    b = eM;
+    var d = cM(String.fromCharCode(116)),
+        c = cM(String.fromCharCode(107)),
+        d = [d(), d()];
+    d[1] = c();
+    for (var c = cb + d.join(k) +
+            of, d = [], e = 0, f = 0; f < a.length; f++) {
+        var g = a.charCodeAt(f);
+        128 > g ? d[e++] = g : (2048 > g ? d[e++] = g >> 6 | 192 : (55296 == (g & 64512) && f + 1 < a.length && 56320 == (a.charCodeAt(f + 1) & 64512) ? (g = 65536 + ((g & 1023) << 10) + (a.charCodeAt(++f) & 1023), d[e++] = g >> 18 | 240, d[e++] = g >> 12 & 63 | 128) : d[e++] = g >> 12 | 224, d[e++] = g >> 6 & 63 | 128), d[e++] = g & 63 | 128)
+    }
+    console.log(d)
+    a = b || 0;
+    for (e = 0; e < d.length; e++) a += d[e], a = dM(a, Vb);
+    a = dM(a, Ub);
+    0 > a && (a = (a & 2147483647) + 2147483648);
+    a %= 1E6;
+    return a.toString() + dd + (a ^ b)
+};
+
+console.log(fM("Hey asshole"));


### PR DESCRIPTION
In recent times Google has introduced a token to Translate, which is used to verify the text to speech request. I reverse engineered this process:

* A token key is globally set as the TKK variable in window
* This key and the text are hashed and a token is generated

I managed to port this process to Python. This does mean an extra request is required to get the TKK from the translate site (though it seems to increment by time, so maybe someone can find some connection). Also this is rather fragile as Google can simply change the hashing formula very slightly and this will break.