### PR TITLE
Fixes for Python 3.x

### DIFF
--- a/bin/gtts-cli.py
+++ b/bin/gtts-cli.py
@@ -8,7 +8,7 @@ import argparse
 
 def languages():
     """Sorted pretty printed string of supported languages"""
-    return ", ".join(sorted("{}: '{}'".format(v,k) for k,v in gTTS.LANGUAGES.iteritems()))
+    return ", ".join(sorted("{}: '{}'".format(gTTS.LANGUAGES[k], k) for k in gTTS.LANGUAGES))
 
 # Args
 desc = "Creates an mp3 file from spoken text via the Google Text-to-Speech API ({v})".format(v=__version__)

--- a/bin/gtts-cli.py
+++ b/bin/gtts-cli.py
@@ -5,6 +5,7 @@ from gtts import gTTS
 from gtts import __version__
 import sys
 import argparse
+import os
 
 def languages():
     """Sorted pretty printed string of supported languages"""
@@ -37,7 +38,7 @@ try:
     if args.destination:
         tts.save(args.destination)
     else:
-        tts.write_to_fp(sys.stdout)
+        tts.write_to_fp(os.fdopen(sys.stdout.fileno(), "wb"))
 
 except Exception as e:
     if args.destination:


### PR DESCRIPTION
Fixes for Python 3:
* `dict.iteritems()` does not exist in Python 3 (it has been replaced by `dict.items()`)
* `sys.stdout` is open in text mode, so you can't write a binary file to it without reopening it in binary mode

The following code works with both Python 2 & 3 (tested with 2.7 & 3.4).