### PR TITLE
Better Python 2/3 compatibility and http proxies:

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     description='Create an mp3 file from spoken text via the Google TTS (Text-to-Speech) API',
     long_description=open('README.md').read(),
     install_requires=[
+        "six",
         "requests",
         "gtts_token"
     ],


### PR DESCRIPTION
  - Getting proper length of Python 2 unicode
  - Using 'six' for Python 2/3 urllib
  - Passing os http proxy settings to the api request