### PR TITLE
Include the LICENSE file in the sdist tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include CHANGELOG.md
+include LICENSE


### PR DESCRIPTION
The MIT license demands the copyright notice and license text to be
included in all copy of the software, which would include the tarball
produced by sdist and uploaded to pypi, which is currently lacking it.