### PR TITLE
Remove client-side check for language support

### DIFF
--- a/gtts/tests/test_tts.py
+++ b/gtts/tests/test_tts.py
@@ -5,7 +5,13 @@ import unittest
 
 from gtts import gTTS
 
-LANGS = [lang for lang in gTTS.LANGUAGES.keys()]
+LANGS = [
+    'af', 'sq', 'ar', 'hy', 'bn', 'ca', 'zh', 'zh-cn', 'zh-tw', 'zh-yue', 'hr',
+    'cs', 'da', 'nl', 'en', 'en-au', 'en-uk', 'en-us', 'eo', 'fi', 'fr', 'de',
+    'el', 'hi', 'hu', 'is', 'id', 'it', 'ja', 'km', 'ko', 'la', 'lv', 'mk',
+    'no', 'pl', 'pt', 'ro', 'ru', 'sr', 'si', 'sk', 'es', 'es-es', 'es-us',
+    'sw', 'sv', 'ta', 'th', 'tr', 'uk', 'vi', 'cy',
+]
 
 class TestLanguages(unittest.TestCase):
     """Test all supported languages and file save"""

--- a/gtts/tts.py
+++ b/gtts/tts.py
@@ -15,68 +15,10 @@ class gTTS:
 
     GOOGLE_TTS_URL = 'https://translate.google.com/translate_tts'
     MAX_CHARS = 100 # Max characters the Google TTS API takes at a time
-    LANGUAGES = {
-        'af' : 'Afrikaans',
-        'sq' : 'Albanian',
-        'ar' : 'Arabic',
-        'hy' : 'Armenian',
-        'bn' : 'Bengali',
-        'ca' : 'Catalan',
-        'zh' : 'Chinese',
-        'zh-cn' : 'Chinese (Mandarin/China)',
-        'zh-tw' : 'Chinese (Mandarin/Taiwan)',
-        'zh-yue' : 'Chinese (Cantonese)',
-        'hr' : 'Croatian',
-        'cs' : 'Czech',
-        'da' : 'Danish',
-        'nl' : 'Dutch',
-        'en' : 'English',
-        'en-au' : 'English (Australia)',
-        'en-uk' : 'English (United Kingdom)',
-        'en-us' : 'English (United States)',
-        'eo' : 'Esperanto',
-        'fi' : 'Finnish',
-        'fr' : 'French',
-        'de' : 'German',
-        'el' : 'Greek',
-        'hi' : 'Hindi',
-        'hu' : 'Hungarian',
-        'is' : 'Icelandic',
-        'id' : 'Indonesian',
-        'it' : 'Italian',
-        'ja' : 'Japanese',
-        'km' : 'Khmer (Cambodian)',
-        'ko' : 'Korean',
-        'la' : 'Latin',
-        'lv' : 'Latvian',
-        'mk' : 'Macedonian',
-        'no' : 'Norwegian',
-        'pl' : 'Polish',
-        'pt' : 'Portuguese',
-        'ro' : 'Romanian',
-        'ru' : 'Russian',
-        'sr' : 'Serbian',
-        'si' : 'Sinhala',
-        'sk' : 'Slovak',
-        'es' : 'Spanish',
-        'es-es' : 'Spanish (Spain)',
-        'es-us' : 'Spanish (United States)',
-        'sw' : 'Swahili',
-        'sv' : 'Swedish',
-        'ta' : 'Tamil',
-        'th' : 'Thai',
-        'tr' : 'Turkish',
-        'uk' : 'Ukrainian',
-        'vi' : 'Vietnamese',
-        'cy' : 'Welsh'
-    }
 
     def __init__(self, text, lang = 'en', slow = False, debug = False):
         self.debug = debug
-        if lang.lower() not in self.LANGUAGES:
-            raise Exception('Language not supported: %s' % lang)
-        else:
-            self.lang = lang.lower()
+        self.lang = lang.lower()
 
         if not text:
             raise Exception('No text to speak')


### PR DESCRIPTION
Don't check for language support on the client side, since the list
of supported languages is rapidly evolving, and even some undocumented
language codes are accepted, e.g. "de" for German, in addition to the
documented "de-DE".

By not checking the language code on the client side, using an invalid
code will raise a 404 exception when the request is made:

    requests.exceptions.HTTPError: 404 Client Error: <snip>