### PR TITLE
Add support for Estonian language

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ $ echo "Hello" | gtts-cli -l 'en' -o hello.mp3 -
   * 'en-uk' : 'English (United Kingdom)'
   * 'en-us' : 'English (United States)'
   * 'eo' : 'Esperanto'
+  * 'et' : 'Estonian'
   * 'fi' : 'Finnish'
   * 'fr' : 'French'
   * 'de' : 'German'

--- a/gtts/tts.py
+++ b/gtts/tts.py
@@ -35,6 +35,7 @@ class gTTS:
         'en-uk' : 'English (United Kingdom)',
         'en-us' : 'English (United States)',
         'eo' : 'Esperanto',
+        'et' : 'Estonian',
         'fi' : 'Finnish',
         'fr' : 'French',
         'de' : 'German',


### PR DESCRIPTION
Estonian TTS was added to Google along with Romanian and Slovak.

Ref http://www.androidpolice.com/2018/01/08/google-text-speech-adds-support-estonian-romanian-slovak-apk-download/