### PR TITLE
setup.cfg: Require beautifulsoup4 instead of bs4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ include_package_data = True
 packages = find:
 install_requires =
   six
-  bs4
+  beautifulsoup4
   click
   requests
   gtts_token >= 1.1.3


### PR DESCRIPTION
bs4 is just "alias" on PyPI [1] and official name is beautifulsoup4.

[1] https://pypi.org/project/bs4/