### PR TITLE
Enable to get tts urls without API calls

### DIFF
--- a/gtts/tests/test_tts.py
+++ b/gtts/tests/test_tts.py
@@ -2,6 +2,7 @@
 import os
 import pytest
 from mock import Mock
+from six.moves import urllib
 
 from gtts.tts import gTTS, gTTSError
 from gtts.lang import _fetch_langs, _extra_langs
@@ -96,6 +97,20 @@ def test_save(tmp_path):
 
     # Check if file created is > 2k
     assert filename.stat().st_size > 2000
+
+
+def test_get_urls():
+    """Get request urls to download audio file"""
+    tts = gTTS(text='test', lang='en-uk')
+    urls = tts.get_urls()
+
+    # Check the url
+    r = urllib.parse.urlparse(urls[0])
+    assert r.scheme == 'https'
+    assert r.netloc == 'translate.google.com'
+    assert r.path == '/translate_tts'
+    assert 'test' in urllib.parse.parse_qs(r.query)['q']
+    assert 'en-uk' in urllib.parse.parse_qs(r.query)['tl']
 
 
 def test_msg():

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@ tests =
   flake8
   testfixtures
   mock
+  six
 docs =
   sphinx 
   sphinx-autobuild


### PR DESCRIPTION
Some audio devices (e.g. chromecast, google home)
and its library (e.g. pychromecast[1]) only accept
the download urls for the audio file you want to play.

To let other devices download and play it, it is
useful to get the tts urls without calling API.

[1] https://github.com/balloob/pychromecast