### PR TITLE
Added Blank/Null Check in part causing 404 Error

### DIFF
--- a/gtts/tts.py
+++ b/gtts/tts.py
@@ -189,6 +189,9 @@ class gTTS:
 
         prepared_requests = []
         for idx, part in enumerate(text_parts):
+            if part is None or part=='':
+                # Skip blank tokens
+                continue
             try:
                 # Calculate token
                 part_tk = self.token.calculate_token(part)


### PR DESCRIPTION
If the part is blank the translate api is returning **404 Error** in result **gTTS** raises **HTTPError**. Adding this Check will solve 404 Error when using Unicode web Scrapped content. 