### PR TITLE
Tokenizer method debug fix

### DIFF
--- a/gtts/tts.py
+++ b/gtts/tts.py
@@ -123,7 +123,7 @@ class gTTS:
 
         # Debug
         for k, v in dict(locals()).items():
-            if k == 'self':
+            if k == 'self' or k == "tokenizer_func":
                 continue
             log.debug("%s: %s", k, v)
 


### PR DESCRIPTION
Working around some debug log errors that pop up when trying to log the tokenizer methods.