### PR TITLE
Restore u-strings removed by Black for Py2 tests

### DIFF
--- a/gtts/tests/test_cli.py
+++ b/gtts/tests/test_cli.py
@@ -131,7 +131,7 @@ test
 123"""
 
 # Text for stdin ('-' for <text> or <file>) (Unicode)
-textstdin_unicode = """你吃饭了吗？
+textstdin_unicode = u"""你吃饭了吗？
 你最喜欢哪部电影？
 我饿了，我要去做饭了。"""
 
@@ -142,7 +142,7 @@ How much will it cost the website doesn't have the theme i was going for."""
 textfile_ascii = os.path.join(pwd, "input_files", "test_cli_test_ascii.txt")
 
 # Text for <text> and <file> (Unicode)
-text_unicode = """这是一个三岁的小孩
+text_unicode = u"""这是一个三岁的小孩
 在讲述她从一系列照片里看到的东西。
 对这个世界， 她也许还有很多要学的东西，
 但在一个重要的任务上， 她已经是专家了：

--- a/gtts/tests/test_cli.py
+++ b/gtts/tests/test_cli.py
@@ -161,7 +161,7 @@ def logcapture_str(lc):
     if not lc.records:
         return "No logging captured"
 
-    return "\n".join(["%s %s\n  %s" % r for r in lc.actual()])
+    return "\n".join([u"%s %s\n  %s" % r for r in lc.actual()])
 
 
 @pytest.mark.net

--- a/gtts/tests/test_utils.py
+++ b/gtts/tests/test_utils.py
@@ -19,8 +19,8 @@ def test_ascii_no_delim():
 
 
 def test_unicode():
-    _in = "这是一个三岁的小孩在讲述他从一系列照片里看到的东西。"
-    _out = ["这是一个三岁的小孩在", "讲述他从一系列照片里", "看到的东西。"]
+    _in = u"这是一个三岁的小孩在讲述他从一系列照片里看到的东西。"
+    _out = [u"这是一个三岁的小孩在", u"讲述他从一系列照片里", u"看到的东西。"]
     assert _minimize(_in, delim, Lmax) == _out
 
 
@@ -36,7 +36,7 @@ def test_len_ascii():
 
 
 def test_len_unicode():
-    text = "但在一个重要的任务上"
+    text = u"但在一个重要的任务上"
     assert _len(text) == 10
 
 

--- a/gtts/tokenizer/core.py
+++ b/gtts/tokenizer/core.py
@@ -182,7 +182,7 @@ class PreProcessorSub:
 
     def __init__(self, sub_pairs, ignore_case=True):
         def search_func(x):
-            return "{}".format(x)
+            return u"{}".format(x)
 
         flags = re.I if ignore_case else 0
 

--- a/gtts/tokenizer/pre_processors.py
+++ b/gtts/tokenizer/pre_processors.py
@@ -12,7 +12,7 @@ def tone_marks(text):
     """
     return PreProcessorRegex(
         search_args=symbols.TONE_MARKS,
-        search_func=lambda x: "(?<={})".format(x),
+        search_func=lambda x: u"(?<={})".format(x),
         repl=" ",
     ).run(text)
 
@@ -24,7 +24,7 @@ def end_of_line(text):
 
     """
     return PreProcessorRegex(
-        search_args="-", search_func=lambda x: "{}\n".format(x), repl=""
+        search_args="-", search_func=lambda x: u"{}\n".format(x), repl=""
     ).run(text)
 
 

--- a/gtts/tokenizer/symbols.py
+++ b/gtts/tokenizer/symbols.py
@@ -4,10 +4,10 @@ ABBREVIATIONS = ["dr", "jr", "mr", "mrs", "ms", "msgr", "prof", "sr", "st"]
 
 SUB_PAIRS = [("Esq.", "Esquire")]
 
-ALL_PUNC = "?!？！.,¡()[]¿…‥،;:—。，、：\n"
+ALL_PUNC = u"?!？！.,¡()[]¿…‥،;:—。，、：\n"
 
-TONE_MARKS = "?!？！"
+TONE_MARKS = u"?!？！"
 
 PERIOD_COMMA = ".,"
 
-COLON = ":"
+COLON = u":"

--- a/gtts/tokenizer/tokenizer_cases.py
+++ b/gtts/tokenizer/tokenizer_cases.py
@@ -9,7 +9,7 @@ def tone_marks():
     not be any space after a tone-modifying punctuation mark.
     """
     return RegexBuilder(
-        pattern_args=symbols.TONE_MARKS, pattern_func=lambda x: "(?<={}).".format(x)
+        pattern_args=symbols.TONE_MARKS, pattern_func=lambda x: u"(?<={}).".format(x)
     ).regex
 
 
@@ -57,7 +57,7 @@ def other_punctuation():
         - set(symbols.PERIOD_COMMA)
         - set(symbols.COLON)
     )
-    return RegexBuilder(pattern_args=punc, pattern_func=lambda x: "{}".format(x)).regex
+    return RegexBuilder(pattern_args=punc, pattern_func=lambda x: u"{}".format(x)).regex
 
 
 def legacy_all_punctuation():  # pragma: no cover b/c tested but Coveralls: ¯\_(ツ)_/¯
@@ -66,4 +66,4 @@ def legacy_all_punctuation():  # pragma: no cover b/c tested but Coveralls: ¯\_
     Use as only tokenizer case to mimic gTTS 1.x tokenization.
     """
     punc = symbols.ALL_PUNC
-    return RegexBuilder(pattern_args=punc, pattern_func=lambda x: "{}".format(x)).regex
+    return RegexBuilder(pattern_args=punc, pattern_func=lambda x: u"{}".format(x)).regex

--- a/gtts/utils.py
+++ b/gtts/utils.py
@@ -3,7 +3,7 @@ from gtts.tokenizer.symbols import ALL_PUNC as punc
 from string import whitespace as ws
 import re
 
-_ALL_PUNC_OR_SPACE = re.compile("^[{}]*$".format(re.escape(punc + ws)))
+_ALL_PUNC_OR_SPACE = re.compile(u"^[{}]*$".format(re.escape(punc + ws)))
 """Regex that matches if an entire line is only comprised
 of whitespace and punctuation
 


### PR DESCRIPTION
As per title—
Black removed the `u` strings. Restore them (for now), until Python 2 gets ripped out for good.