### PR TITLE
Remove mock package test dependancy

### DIFF
--- a/gtts/tests/test_tts.py
+++ b/gtts/tests/test_tts.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import pytest
-from mock import Mock
+from unittest.mock import Mock
 from six.moves import urllib
 
 from gtts.tts import gTTS, gTTSError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ tests = [
     "pytest ~= 7.1.3",
     "pytest-cov",
     "testfixtures",
-    "mock"
 ]
 docs = [
     "sphinx",


### PR DESCRIPTION
This PR,
* [Removes the dependancy on the `mock` package](https://github.com/pndurette/gTTS/issues/343#issuecomment-1073994913), not necessary after Python 3.3

Fixes #343