### PR TITLE
Loosen dependancies for `click` and `requests`, removes `six` dependancy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'gtts/**'
+      - 'pyproject.toml'
 
 jobs:
   test:

--- a/gtts/tests/test_tts.py
+++ b/gtts/tests/test_tts.py
@@ -2,7 +2,6 @@
 import os
 import pytest
 from unittest.mock import Mock
-from six.moves import urllib
 
 from gtts.tts import gTTS, gTTSError
 from gtts.langs import _main_langs

--- a/gtts/tts.py
+++ b/gtts/tts.py
@@ -1,21 +1,15 @@
 # -*- coding: utf-8 -*-
-from gtts.tokenizer import pre_processors, Tokenizer, tokenizer_cases
-from gtts.utils import _minimize, _len, _clean_tokens, _translate_url
-from gtts.lang import tts_langs, _fallback_deprecated_lang
-
-from six.moves import urllib
-
-try:
-    from urllib.parse import quote
-    import urllib3
-except ImportError:
-    from urllib import quote
-    import urllib2
-import requests
-import logging
-import json
-import re
 import base64
+import json
+import logging
+import re
+import urllib
+
+import requests
+
+from gtts.lang import _fallback_deprecated_lang, tts_langs
+from gtts.tokenizer import Tokenizer, pre_processors, tokenizer_cases
+from gtts.utils import _clean_tokens, _len, _minimize, _translate_url
 
 __all__ = ["gTTS", "gTTSError"]
 
@@ -233,7 +227,7 @@ class gTTS:
 
         rpc = [[[self.GOOGLE_TTS_RPC, escaped_parameter, None, "generic"]]]
         espaced_rpc = json.dumps(rpc, separators=(",", ":"))
-        return "f.req={}&".format(quote(espaced_rpc))
+        return "f.req={}&".format(urllib.parse.quote(espaced_rpc))
 
     def get_bodies(self):
         """Get TTS API request bodies(s) that would be sent to the TTS API.
@@ -253,7 +247,9 @@ class gTTS:
         # When disabling ssl verify in requests (for proxies and firewalls),
         # urllib3 prints an insecure warning on stdout. We disable that.
         try:
-            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+            requests.packages.urllib3.disable_warnings(
+                requests.packages.urllib3.exceptions.InsecureRequestWarning
+            )
         except:
             pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 dependencies = [
     "requests ~= 2.28.0",
-    "click ~= 8.1.3",
+    "click >=7.1, <8.2",
     "six ~= 1.16.0"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ classifiers = [
 dependencies = [
     "requests >=2.27, <3",  # https://docs.python-requests.org/en/latest/community/updates/
     "click >=7.1, <8.2",    # https://click.palletsprojects.com/en/latest/changes/
-    "six ~= 1.16.0"
 ]
 
 # TODO: release-please [yet] doesn't support dynamic version for pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,8 @@ classifiers = [
     "Topic :: Multimedia :: Sound/Audio :: Speech",
 ]
 dependencies = [
-    "requests ~= 2.28.0",
-    "click >=7.1, <8.2",
+    "requests >=2.27, <3",  # https://docs.python-requests.org/en/latest/community/updates/
+    "click >=7.1, <8.2",    # https://click.palletsprojects.com/en/latest/changes/
     "six ~= 1.16.0"
 ]
 


### PR DESCRIPTION
This PR,
* Removes the dependancy on `six` (only needed for Python 2.7 compatibility)
* Loosens the dependancy on `click` and `requests`
* Re-organizes imports

Also,
* Adds `pyproject.toml` to the triggers for the unit tests GitHub Action

Fixes #388 