### PR TITLE
Fallback languages in CLI, update old example, add error case

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -24,9 +24,9 @@ Read "c'est la vie" in French to ``cestlavie.mp3``::
 
    $ gtts-cli "c'est la vie" --lang fr --output cestlavie.mp3
 
-Read '你好' to ``你好.mp3`` (in Mandarin, using google.cn)::
+Read '你好' to ``你好.mp3`` (in Mandarin, using google.com.hk)::
 
-   $ gtts-cli '你好' --tld cn --lang zh-cn --output 你好.mp3
+   $ gtts-cli '你好' --tld .com.hk --lang zh-CN --output 你好.mp3
 
 Read 'slow' slowly to ``slow.mp3``::
 

--- a/gtts/cli.py
+++ b/gtts/cli.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from gtts import gTTS, gTTSError, __version__
-from gtts.lang import tts_langs
+from gtts.lang import tts_langs, _fallback_deprecated_lang
 import click
 import logging
 import logging.config
@@ -45,6 +45,9 @@ def validate_lang(ctx, param, lang):
     """
     if ctx.params["nocheck"]:
         return lang
+
+    # Fallback from deprecated language if needed
+    lang = _fallback_deprecated_lang(lang)
 
     try:
         if lang not in tts_langs():

--- a/gtts/tts.py
+++ b/gtts/tts.py
@@ -42,7 +42,7 @@ class gTTS:
             can produce different localized 'accents' for a given
             language. This is also useful when ``google.com`` might be blocked
             within a network but a local or different Google host
-            (e.g. ``google.cn``) is not. Default is ``com``.
+            (e.g. ``google.com.hk``) is not. Default is ``com``.
         lang (string, optional): The language (IETF language tag) to
             read the text in. Default is ``en``.
         slow (bool, optional): Reads text more slowly. Defaults to ``False``.
@@ -364,6 +364,8 @@ class gTTSError(Exception):
 
             if status == 403:
                 cause = "Bad token or upstream API changes"
+            elif status == 404 and tts.tld != "com":
+                cause = "Unsupported tld '{}'".format(tts.tld)
             elif status == 200 and not tts.lang_check:
                 cause = (
                     "No audio stream in response. Unsupported language '%s'"


### PR DESCRIPTION
This PR,

* Adds language fallback support for the CLI
* Updates an old example in the docs (The `.cn` endpoint doesn't seem to work anymore, if you go to `http://translate.google.cn` it tells you to use `https://translate.google.com.hk` instead)
* Adds a new error case for when the non-`.com` TLD host is valid, but the complete API url gives a 404

Fixes #410