### PR TITLE
Flush file after saving

### DIFF
--- a/gtts/tts.py
+++ b/gtts/tts.py
@@ -333,6 +333,7 @@ class gTTS:
         """
         with open(str(savefile), "wb") as f:
             self.write_to_fp(f)
+            f.flush()
             log.debug("Saved to %s", savefile)
 
 


### PR DESCRIPTION
This ensures that other libraries like `playsound` can immediately play the saved audio file.