### PR TITLE
chore(docs): fix typos

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,7 +1,7 @@
 name: Upload Code Coverage
 
 # For the Codecov to do a code coverage diff in a PR,
-# it must have a code coverage of the PR base banch
+# it must have a code coverage of the PR base branch
 # (i.e. typically main). This Action runs tests on main
 # so the code coverage results can be uploaded and
 # a diff to appear in PRs.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -43,7 +43,7 @@ Read ``stdin`` to ``hello.mp3`` via ``<text>`` or ``<file>``::
 
 Read 'no check' to ``nocheck.mp3`` without language checking::
 
-   $ gtts-cli 'no check' --lang zh --nocheck --ouput nocheck.mp3
+   $ gtts-cli 'no check' --lang zh --nocheck --output nocheck.mp3
 
 .. note:: Using ``--nocheck`` can speed up execution. It exists mostly however to force a ``<lang>`` language tag that might not be documented but would work with the API, such as for specific regional sub-tags of documented tags (examples for 'en': 'en-gb', 'en-au', etc.).
 
@@ -53,4 +53,3 @@ Playing sound directly
 You can pipe the output of ``gtts-cli`` into any media player that supports ``stdin``. For example, using the ``play`` command from `SoX <http://sox.sourceforge.net>`_::
 
    $ gtts-cli 'hello' | play -t mp3 -
-

--- a/docs/tokenizer.rst
+++ b/docs/tokenizer.rst
@@ -12,15 +12,15 @@ Definitions
 -----------
 
 Pre-processor:
-    Function that takes text and returns text. Its goal is to modify text (for example correcting pronounciation), and/or to prepare text for proper tokenization (for example ensuring spacing after certain characters).
+    Function that takes text and returns text. Its goal is to modify text (for example correcting pronunciation), and/or to prepare text for proper tokenization (for example ensuring spacing after certain characters).
 
 Tokenizer:
     Function that takes text and returns it split into a list of `tokens` (strings).
     In the ``gTTS`` context, its goal is to cut the text into smaller segments that do not exceed the maximum character size allowed for each TTS API request, while making the speech sound natural and continuous.
-    It does so by splitting text where speech would naturaly pause (for example on ".") while handling where it should not (for example on "10.5" or "U.S.A."). Such rules are called `tokenizer cases`, which it takes a list of.
+    It does so by splitting text where speech would naturally pause (for example on ".") while handling where it should not (for example on "10.5" or "U.S.A."). Such rules are called `tokenizer cases`, which it takes a list of.
 
 Tokenizer case:
-    Function that defines one of the specific cases used by :class:`gtts.tokenizer.core.Tokenizer`. More specefically, it returns a ``regex`` object that describes what to look for for a particular case. :class:`gtts.tokenizer.core.Tokenizer` then creates its main `regex` pattern by joining all `tokenizer cases` with "|".
+    Function that defines one of the specific cases used by :class:`gtts.tokenizer.core.Tokenizer`. More specifically, it returns a ``regex`` object that describes what to look for for a particular case. :class:`gtts.tokenizer.core.Tokenizer` then creates its main `regex` pattern by joining all `tokenizer cases` with "|".
 
 
 Pre-processing
@@ -104,7 +104,7 @@ This module provides a class to help build tokenizer cases: :class:`gtts.tokeniz
 Using a 3rd-party tokenizer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Even though :class:`gtts.tokenizer.core.Tokenizer` works well in this context, there are way more advanced tokenizers and tokenzing techniques. As long as you can restrict the lenght of output tokens, you can use any tokenizer you'd like, such as the ones in `NLTK <http://www.nltk.org>`_.
+Even though :class:`gtts.tokenizer.core.Tokenizer` works well in this context, there are way more advanced tokenizers and tokenzing techniques. As long as you can restrict the length of output tokens, you can use any tokenizer you'd like, such as the ones in `NLTK <http://www.nltk.org>`_.
 
 Minimizing
 ----------

--- a/gtts/tokenizer/core.py
+++ b/gtts/tokenizer/core.py
@@ -11,7 +11,7 @@ class RegexBuilder:
     single pattern.
 
     Args:
-        pattern_args (iteratable): String element(s) to be each passed to
+        pattern_args (iterable): String element(s) to be each passed to
             ``pattern_func`` to create a regex pattern. Each element is
             ``re.escape``'d before being passed.
         pattern_func (callable): A 'template' function that should take a
@@ -78,7 +78,7 @@ class PreProcessorRegex:
     replacement parameter.
 
     Args:
-        search_args (iteratable): String element(s) to be each passed to
+        search_args (iterable): String element(s) to be each passed to
             ``search_func`` to create a regex pattern. Each element is
             ``re.escape``'d before being passed.
         search_func (callable): A 'template' function that should take a
@@ -159,7 +159,7 @@ class PreProcessorSub:
         ignore_case (bool): Ignore case during search. Defaults to ``True``.
 
     Example:
-        Replace all occurences of "Mac" to "PC" and "Firefox" to "Chrome"::
+        Replace all occurrences of "Mac" to "PC" and "Firefox" to "Chrome"::
 
             >>> sub_pairs = [('Mac', 'PC'), ('Firefox', 'Chrome')]
             >>> pp = PreProcessorSub(sub_pairs)
@@ -244,11 +244,11 @@ class Tokenizer:
 
     Warning:
         Joined ``regex`` patterns can easily interfere with one another in
-        unexpected ways. It is recommanded that each tokenizer case operate
-        on distinct or non-overlapping chracters/sets of characters
+        unexpected ways. It is recommended that each tokenizer case operate
+        on distinct or non-overlapping characters/sets of characters
         (For example, a tokenizer case for the period (".") should also
         handle not matching/cutting on decimals, instead of making that
-        a seperate tokenizer case).
+        a separate tokenizer case).
 
     Example:
         A tokenizer with a two simple case (*Note: these are bad cases to

--- a/gtts/tts.py
+++ b/gtts/tts.py
@@ -82,7 +82,7 @@ class gTTS:
 
     Raises:
         AssertionError: When ``text`` is ``None`` or empty; when there's nothing
-            left to speak after pre-precessing, tokenizing and cleaning.
+            left to speak after pre-processing, tokenizing and cleaning.
         ValueError: When ``lang_check`` is ``True`` and ``lang`` is not supported.
         RuntimeError: When ``lang_check`` is ``True`` but there's an error loading
             the languages dictionary.

--- a/scripts/gen_langs.py
+++ b/scripts/gen_langs.py
@@ -43,7 +43,7 @@ def _fetch_langs(tld="com"):
             Default is ``com``.
 
     Returns:
-        dict: A dictionnary of languages from Google Translate
+        dict: A dictionary of languages from Google Translate
 
     """
     LANGUAGES_URL = _translate_url(tld + "/translate_a/l").strip("/")


### PR DESCRIPTION
Found via `codespell -S CHANGELOG.md -L vie,te` and `typos --hidden --format brief`