### PR TITLE
test: fix/simplify `--all` cli test to work with new languages codes

### DIFF
--- a/gtts/tests/test_cli.py
+++ b/gtts/tests/test_cli.py
@@ -75,7 +75,7 @@ def test_all():
     # One or more of "  xy: name" (\n optional to match the last)
     # Ex. "<start>  xx: xxxxx\n  xx-yy: xxxxx\n  xx: xxxxx<end>"
 
-    assert re.match(r"^(?:\s{2}(\w{2}|\w{2}-\w{2}): .+\n?)+$", result.output)
+    assert re.match(r"(\s{2}[\w-]{2,5}: .+\n?)", result.output)
     assert result.exit_code == 0
 
 


### PR DESCRIPTION
This PR,

* Fixes the `--all` CLI test to work with new languages by updating the regular expression in the `test_all()` function in the `gtts/tests/test_cli.py` file.
  * This regression was introduced when upstream introduced a 3 char language code in https://github.com/pndurette/gTTS/commit/72a7e57c0bfa2a6f1f81fc4ce485d9f920ae845c
